### PR TITLE
[pkg/cli] fix the issue with the signals and context

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -7,12 +7,15 @@ import (
 	"syscall"
 )
 
-var sig = make(chan os.Signal, 4)
+var signals = []os.Signal{
+	syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGABRT,
+}
 
 // Context returns a context that is cancelled automatically when a kill signal received
 func Context() context.Context {
+	var sig = make(chan os.Signal, len(signals))
 	ctx, cancel := context.WithCancel(context.Background())
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGABRT)
+	signal.Notify(sig, signals...)
 	go func() {
 		<-sig
 		cancel()

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestContext(t *testing.T) {
+func TestCliContext(t *testing.T) {
+	signals = append(signals, syscall.SIGUSR1)
 	ctx := Context()
 	select {
 	case <-ctx.Done():
 		require.True(t, false, "context canceled early")
 	default:
 	}
-	sig <- syscall.SIGINT
+	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
 
 	select {
 	case <-ctx.Done():
 	case <-time.After(time.Second):
 		require.True(t, false, "context not canceled")
 	}
-
 }


### PR DESCRIPTION
os.Notify sends the signal without waiting for the receiver if we create
many context this way, some of them might miss the signal, since the sig
channel is out of capacity